### PR TITLE
fix: Hide Java logo icon when sidebar is collapsed

### DIFF
--- a/src/css/dashboard.css
+++ b/src/css/dashboard.css
@@ -303,7 +303,8 @@ body {
 .sidebar.collapsed .link-text,
 .sidebar.collapsed .submenu-toggle,
 .sidebar.collapsed .commit-details, /* Ocultar detalles del commit */
-.sidebar.collapsed .user-details { /* Ocultar detalles del usuario */
+.sidebar.collapsed .user-details, /* Ocultar detalles del usuario */
+.sidebar.collapsed .logo-icon { /* Ocultar icono de Java */
     opacity: 0;
     width: 0;
     height: 0; /* Asegurar colapso vertical */

--- a/src/css/exercises.css
+++ b/src/css/exercises.css
@@ -360,7 +360,8 @@ body {
 .sidebar.collapsed .link-text,
 .sidebar.collapsed .submenu-toggle,
 .sidebar.collapsed .commit-details, /* Ocultar detalles del commit */
-.sidebar.collapsed .user-details { /* Ocultar detalles del usuario */
+.sidebar.collapsed .user-details, /* Ocultar detalles del usuario */
+.sidebar.collapsed .logo-icon { /* Ocultar icono de Java */
     opacity: 0;
     width: 0;
     height: 0; /* Asegurar colapso vertical */


### PR DESCRIPTION
- Added .sidebar.collapsed .logo-icon rule in dashboard.css
- Added .sidebar.collapsed .logo-icon rule in exercises.css
- Logo icon now properly disappears with smooth transition when sidebar collapses
- Maintains consistent collapsed sidebar appearance across all pages